### PR TITLE
Update location of add_udev_rules.sh to use GitHub link rather than ledgerwallet.com

### DIFF
--- a/provision/setup.sh
+++ b/provision/setup.sh
@@ -32,7 +32,7 @@ git checkout tags/nanos-1314
 cd /opt/bolos/
 
 echo "finetuning rights for usb access"
-wget -q -O - https://www.ledgerwallet.com/support/add_udev_rules.sh | bash
+wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | bash
 usermod -a -G plugdev vagrant
 
 echo "Setting up bash profile"


### PR DESCRIPTION
## Description
* Now use [https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh](https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh) rather than [https://www.ledgerwallet.com/support/add_udev_rules.sh](https://www.ledgerwallet.com/support/add_udev_rules.sh) as the latter now produces a 404 and is no longer working. Without this provisioning will not work and no comms with the ledger device can take place.